### PR TITLE
Revert "docs: change "default role" wording to "predefined role""

### DIFF
--- a/doc/src/sgml/monitoring.sgml
+++ b/doc/src/sgml/monitoring.sgml
@@ -277,7 +277,7 @@ postgres   27093  0.0  0.0  30096  2752 ?        Ss   11:34   0:00 postgres: ser
    existence of a session and its general properties such as its sessions user
    and database are visible to all users.  Superusers and members of the
    built-in role <literal>pg_read_all_stats</literal> (see also <xref
-   linkend="predefined-roles"/>) can see all the information about all sessions.
+   linkend="default-roles"/>) can see all the information about all sessions.
   </para>
 
   <table id="monitoring-stats-dynamic-views-table">

--- a/doc/src/sgml/user-manag.sgml
+++ b/doc/src/sgml/user-manag.sgml
@@ -483,30 +483,30 @@ DROP ROLE doomed_role;
   </para>
  </sect1>
 
- <sect1 id="predefined-roles">
-  <title>Predefined Roles</title>
+ <sect1 id="default-roles">
+  <title>Default Roles</title>
 
-  <indexterm zone="predefined-roles">
+  <indexterm zone="default-roles">
    <primary>role</primary>
   </indexterm>
 
   <para>
-   <productname>PostgreSQL</productname> provides a set of predefined
-   roles which allow access to privileged capabilities and information.
-   Administrators can GRANT these roles to login and non-login roles,
-   providing those roles with access to the specified capabilities and
-   information.
+   <productname>PostgreSQL</productname> provides a set of default roles
+   which provide access to certain, commonly needed, privileged capabilities
+   and information.  Administrators can GRANT these roles to users and/or
+   other roles in their environment, providing those users with access to
+   the specified capabilities and information.
   </para>
 
   <para>
-   The predefined roles are described in <xref linkend="predefined-roles-table"/>.
-   Note that the specific permissions for each of the predefined roles may
+   The default roles are described in <xref linkend="default-roles-table"/>.
+   Note that the specific permissions for each of the default roles may
    change in the future as additional capabilities are added.  Administrators
    should monitor the release notes for changes.
   </para>
 
-   <table tocentry="1" id="predefined-roles-table">
-    <title>Predefined Roles</title>
+   <table tocentry="1" id="default-roles-table">
+    <title>Default Roles</title>
     <tgroup cols="2">
      <thead>
       <row>
@@ -565,8 +565,8 @@ DROP ROLE doomed_role;
   <literal>pg_read_all_stats</literal> and <literal>pg_stat_scan_tables</literal>
   roles are intended to allow administrators to easily configure a role for the
   purpose of monitoring the database server. They grant a set of common privileges
-  allowing the role to read configuration settings, statistics, and other
-  system information normally restricted to superusers.
+  allowing the role to read various useful configuration settings, statistics and
+  other system information normally restricted to superusers.
   </para>
 
   <para>


### PR DESCRIPTION
This reverts commit 0e936a2148472e6c364aee8c3e298dc16dc4240a.

Per discussion, we can't change the section title without some
web-site work, so revert this change temporarily.

Discussion: https://postgr.es/m/157742545062.1149.11052653770497832538@wrigleys.postgresql.org