### PR TITLE
Recreate website's formatting for "website" doc builds.

### DIFF
--- a/doc/src/sgml/docguide.sgml
+++ b/doc/src/sgml/docguide.sgml
@@ -276,6 +276,13 @@ checking for fop... fop
 <prompt>doc/src/sgml$ </prompt><userinput>make STYLE=website html</userinput>
 </screen>
    </para>
+
+   <para>
+    If the <literal>STYLE=website</literal> option is used, the generated HTML
+    files include references to stylesheets hosted on <ulink
+    url="https://www.postgresql.org/docs/current/">postgresql.org</ulink> and
+    require network access to view.
+   </para>
  </sect2>
 
  <sect2>

--- a/doc/src/sgml/stylesheet-html-common.xsl
+++ b/doc/src/sgml/stylesheet-html-common.xsl
@@ -18,6 +18,14 @@
 <xsl:param name="link.mailto.url">pgsql-docs@lists.postgresql.org</xsl:param>
 <xsl:param name="toc.max.depth">2</xsl:param>
 
+<!--
+  The below allows the stylesheets provided by the website to be applied fully
+  to the generated HTML.
+  -->
+<xsl:template name="body.attributes">
+  <xsl:attribute name="id">docContent</xsl:attribute>
+  <xsl:attribute name="class">container-fluid col-10</xsl:attribute>
+</xsl:template>
 
 <!-- Change display of some elements -->
 

--- a/doc/src/sgml/stylesheet.xsl
+++ b/doc/src/sgml/stylesheet.xsl
@@ -23,7 +23,12 @@
 <xsl:param name="html.stylesheet">
   <xsl:choose>
     <xsl:when test="$website.stylesheet = 0">stylesheet.css</xsl:when>
-    <xsl:otherwise>https://www.postgresql.org/media/css/docs.css</xsl:otherwise>
+    <xsl:otherwise>
+      https://www.postgresql.org/media/css/fontawesome.css
+      https://www.postgresql.org/media/css/bootstrap.min.css
+      https://www.postgresql.org/media/css/main.css
+      https://www.postgresql.org/media/css/normalize.css
+    </xsl:otherwise>
   </xsl:choose>
 </xsl:param>
 


### PR DESCRIPTION
The stylesheets used for the HTML documentation rendered on
postgresql.org have shifted, and no longer matched what was expected by
"make STYLE=website html" builds performed locally.  Local doc builds
did not reflect other aspects of the website, including font and
margins.

This patch updates the references to use the current set of stylesheets
that are used by the documentation on postgresql.org. This also wraps
the documentation preview in a HTML container so it can keep the content
within similar margins to those found on the website.

The documentation on building the docs is updated to reflect this
change, and to let the documentation builder know that an external
network connection is required to properly preview documentation built
with "make STYLE=website html" (which was true prior to this patch too,
but not mentioned).

Author: Jonathan Katz
Reported-By: Tom Lane
Discussion: https://postgr.es/m/1375.1581446233@sss.pgh.pa.us