### PR TITLE
Add an explicit test to catch changes in checksumming calculations.

### DIFF
--- a/contrib/pageinspect/Makefile
+++ b/contrib/pageinspect/Makefile
@@ -19,7 +19,7 @@ DATA =  pageinspect--1.7--1.8.sql pageinspect--1.6--1.7.sql \
 	pageinspect--1.0--1.1.sql
 PGFILEDESC = "pageinspect - functions to inspect contents of database pages"
 
-REGRESS = page btree brin gin hash
+REGRESS = page btree brin gin hash checksum
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/pageinspect/expected/checksum.out
+++ b/contrib/pageinspect/expected/checksum.out
@@ -1,0 +1,40 @@
+--
+-- Verify correct calculation of checksums
+--
+-- Postgres' checksum algorithm produces different answers on little-endian
+-- and big-endian machines.  The results of this test also vary depending
+-- on the configured block size.  This test has several different expected
+-- results files to handle the following possibilities:
+--
+--	BLCKSZ	end	file
+--	8K	LE	checksum.out
+--	8K	BE	checksum_1.out
+--
+-- In future we might provide additional expected-results files for other
+-- block sizes, but there seems little point as long as so many other
+-- test scripts also show false failures for non-default block sizes.
+--
+-- This is to label the results files with blocksize:
+SHOW block_size;
+ block_size 
+------------
+ 8192
+(1 row)
+
+SHOW block_size \gset
+-- Apply page_checksum() to some different data patterns and block numbers
+SELECT blkno,
+    page_checksum(decode(repeat('01', :block_size), 'hex'), blkno) AS checksum_01,
+    page_checksum(decode(repeat('04', :block_size), 'hex'), blkno) AS checksum_04,
+    page_checksum(decode(repeat('ff', :block_size), 'hex'), blkno) AS checksum_ff,
+    page_checksum(decode(repeat('abcd', :block_size / 2), 'hex'), blkno) AS checksum_abcd,
+    page_checksum(decode(repeat('e6d6', :block_size / 2), 'hex'), blkno) AS checksum_e6d6,
+    page_checksum(decode(repeat('4a5e', :block_size / 2), 'hex'), blkno) AS checksum_4a5e
+  FROM generate_series(0, 100, 50) AS a (blkno);
+ blkno | checksum_01 | checksum_04 | checksum_ff | checksum_abcd | checksum_e6d6 | checksum_4a5e 
+-------+-------------+-------------+-------------+---------------+---------------+---------------
+     0 |        1175 |       28338 |        3612 |        -30781 |        -16269 |        -27377
+    50 |        1225 |       28352 |        3598 |        -30795 |        -16251 |        -27391
+   100 |        1139 |       28438 |        3648 |        -30881 |        -16305 |        -27349
+(3 rows)
+

--- a/contrib/pageinspect/expected/checksum_1.out
+++ b/contrib/pageinspect/expected/checksum_1.out
@@ -1,0 +1,40 @@
+--
+-- Verify correct calculation of checksums
+--
+-- Postgres' checksum algorithm produces different answers on little-endian
+-- and big-endian machines.  The results of this test also vary depending
+-- on the configured block size.  This test has several different expected
+-- results files to handle the following possibilities:
+--
+--	BLCKSZ	end	file
+--	8K	LE	checksum.out
+--	8K	BE	checksum_1.out
+--
+-- In future we might provide additional expected-results files for other
+-- block sizes, but there seems little point as long as so many other
+-- test scripts also show false failures for non-default block sizes.
+--
+-- This is to label the results files with blocksize:
+SHOW block_size;
+ block_size 
+------------
+ 8192
+(1 row)
+
+SHOW block_size \gset
+-- Apply page_checksum() to some different data patterns and block numbers
+SELECT blkno,
+    page_checksum(decode(repeat('01', :block_size), 'hex'), blkno) AS checksum_01,
+    page_checksum(decode(repeat('04', :block_size), 'hex'), blkno) AS checksum_04,
+    page_checksum(decode(repeat('ff', :block_size), 'hex'), blkno) AS checksum_ff,
+    page_checksum(decode(repeat('abcd', :block_size / 2), 'hex'), blkno) AS checksum_abcd,
+    page_checksum(decode(repeat('e6d6', :block_size / 2), 'hex'), blkno) AS checksum_e6d6,
+    page_checksum(decode(repeat('4a5e', :block_size / 2), 'hex'), blkno) AS checksum_4a5e
+  FROM generate_series(0, 100, 50) AS a (blkno);
+ blkno | checksum_01 | checksum_04 | checksum_ff | checksum_abcd | checksum_e6d6 | checksum_4a5e 
+-------+-------------+-------------+-------------+---------------+---------------+---------------
+     0 |      -16327 |        8766 |       -2722 |         13757 |        -11485 |        -31426
+    50 |      -16281 |        8780 |       -2708 |         13771 |        -11503 |        -31440
+   100 |      -16235 |        8866 |       -2758 |         13721 |        -11577 |        -31518
+(3 rows)
+

--- a/contrib/pageinspect/sql/checksum.sql
+++ b/contrib/pageinspect/sql/checksum.sql
@@ -1,0 +1,31 @@
+--
+-- Verify correct calculation of checksums
+--
+-- Postgres' checksum algorithm produces different answers on little-endian
+-- and big-endian machines.  The results of this test also vary depending
+-- on the configured block size.  This test has several different expected
+-- results files to handle the following possibilities:
+--
+--	BLCKSZ	end	file
+--	8K	LE	checksum.out
+--	8K	BE	checksum_1.out
+--
+-- In future we might provide additional expected-results files for other
+-- block sizes, but there seems little point as long as so many other
+-- test scripts also show false failures for non-default block sizes.
+--
+
+-- This is to label the results files with blocksize:
+SHOW block_size;
+
+SHOW block_size \gset
+
+-- Apply page_checksum() to some different data patterns and block numbers
+SELECT blkno,
+    page_checksum(decode(repeat('01', :block_size), 'hex'), blkno) AS checksum_01,
+    page_checksum(decode(repeat('04', :block_size), 'hex'), blkno) AS checksum_04,
+    page_checksum(decode(repeat('ff', :block_size), 'hex'), blkno) AS checksum_ff,
+    page_checksum(decode(repeat('abcd', :block_size / 2), 'hex'), blkno) AS checksum_abcd,
+    page_checksum(decode(repeat('e6d6', :block_size / 2), 'hex'), blkno) AS checksum_e6d6,
+    page_checksum(decode(repeat('4a5e', :block_size / 2), 'hex'), blkno) AS checksum_4a5e
+  FROM generate_series(0, 100, 50) AS a (blkno);


### PR DESCRIPTION
Seems like a good idea in view of 006517432 and addd034ae.

Michael Paquier, Tom Lane

Discussion: https://postgr.es/m/20200306075230.GA118430@paquier.xyz