### PR TITLE
Doc: Mention about caveats of --concurrently on reindexdb page

### DIFF
--- a/doc/src/sgml/ref/reindexdb.sgml
+++ b/doc/src/sgml/ref/reindexdb.sgml
@@ -122,8 +122,9 @@ PostgreSQL documentation
       <term><option>--concurrently</option></term>
       <listitem>
        <para>
-        Use the <literal>CONCURRENTLY</literal> option.  See <xref
-        linkend="sql-reindex"/> for further information.
+        Use the <literal>CONCURRENTLY</literal> option.  See
+        <xref linkend="sql-reindex"/>, where all the caveats of this option
+        are explained in detail.
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
The documentation of REINDEX includes a complete description of
CONCURRENTLY and its advantages as well as its disadvantages, but
reindexdb was not really clear about all that.

From discussion with Tom Lane, based on a report from Andrey Klychkov.

Discussion: https://postgr.es/m/1590486572.205117372@f500.i.mail.ru
Backpatch-through: 12